### PR TITLE
Add implement the how it works section for desktop screen only

### DIFF
--- a/src/components/HowItworks.jsx
+++ b/src/components/HowItworks.jsx
@@ -3,6 +3,7 @@ import ConnectImg from "../assests/Connect.webp";
 import OverviewImg from "../assests/Overview.webp";
 import arrow1 from "../assests/arrow1.svg";
 import arrow2 from "../assests/arrow2.svg";
+import howitworks from "../assests/howitworks.svg";
 
 const steps = [
   {
@@ -22,11 +23,17 @@ const steps = [
   },
 ];
 
-const HowItworks = () => {
+export const HowItWorks = () => {
   return (
-    <section className="px-8 lg:px-24">
+    <section className="px-8 lg:px-24 lg:py-10">
       <hr className="border border-[#D7D7D7]" />
-      <button>How It Works</button>
+      <button className="border-2 border-[#949494] rounded-lg font-bold  flex items-center gap-x-2  px-4 lg:px-8 py-2 mt-5">
+        {" "}
+        <span>
+          <img src={howitworks} alt="" />
+        </span>
+        How It Works
+      </button>
       <div>
         {steps.map(({ phase, subtext, img }, index) => {
           const isLeft = index % 2 === 0;
@@ -38,32 +45,36 @@ const HowItworks = () => {
                 style={{ zIndex: steps.length - index }}
               >
                 <div
-                  className={`flex items-center ${
+                  className={` flex items-center ${
                     isLeft ? " justify-start" : "justify-end"
                   }`}
                 >
-                  <div className="flex flex-col">
-                    <h5>{phase}</h5>
-                    <p>{subtext}</p>
+                  <div className="flex flex-col mt-8">
+                    <h3 className="font-bold text-black text-xl mb-1">
+                      {phase}
+                    </h3>
+                    <p className="text-[#949494] mb-2 text-base">{subtext}</p>
                     <img
                       src={img}
                       alt=""
                       style={{ width: "400px", height: "auto" }}
-                      className="w-[500px] h-auto"
+                      className="w-[500px] h-auto cursor-pointer transform hover:scale-105 transition-transform duration-300 ease-in-out"
                     />
                   </div>
 
                   {/* Arrow beside the first card */}
                   {index === 0 && (
-                    <img
-                      src={arrow1}
-                      style={{
-                        width: "100px",
-                        height: "auto",
-                        marginLeft: "20px",
-                      }}
-                      alt=""
-                    />
+                    <div className=" flex justify-center mt-90">
+                      <img
+                        src={arrow1}
+                        style={{
+                          width: "100px",
+                          height: "auto",
+                          marginLeft: "160px",
+                        }}
+                        alt=""
+                      />
+                    </div>
                   )}
                 </div>
               </div>
@@ -88,5 +99,3 @@ const HowItworks = () => {
     </section>
   );
 };
-
-export default HowItworks;

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -6,7 +6,7 @@ export default function Home() {
   return (
     <div>
       <HeroSection />
-      <HowItworks />
+      <HowItWorks />
       <Demo />
     </div>
   );


### PR DESCRIPTION
**TL;DR:**  
This component displays a "How It Works" section for desktop, showing three steps (Login, Connect, Overview) with images and descriptions. Steps alternate alignment, and arrows visually connect them. Styling is handled with Tailwind CSS. The first arrow is currently beside the first card; the second arrow is below the second card.